### PR TITLE
BRAV-933: Tinymce upgrade to 4.9.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "angular": "~1.x",
-    "tinymce-dist": "~5.4.2"
+    "tinymce-dist": "~4.9.11"
   },
   "devDependencies": {
     "angular-mocks": "~1.x"


### PR DESCRIPTION
**JIRA Ticket:** https://aprigo.jira.com/browse/BRAV-933

**Purpose:** TinyMCE library upgrade to 4.9.11 for FED compliance.
                Since Cloudlock uses TinyMCE 4, we are upgrading to 4.9.11

**Test Case Document:** https://docs.google.com/spreadsheets/d/1vtd9vk7pa3uytQrsyrtYYM47XeckSdawQCWm23FgVD0/edit?usp=sharing

**Unit Tests:** N/A