### PR TITLE
BRAV-1103: Updated tinymce version to 5.4.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "angular": "~1.x",
-    "tinymce-dist": "~4.9.11"
+    "tinymce-dist": "~5.4.2"
   },
   "devDependencies": {
     "angular-mocks": "~1.x"


### PR DESCRIPTION
JIRA Ticket: https://aprigo.jira.com/browse/BRAV-1103

Purpose: TinyMCE library upgrade to 5.4.2 for FED compliance.
Since Cloudlock uses TinyMCE 4, we are upgrading to 5.4.2

Test Case Document: https://docs.google.com/spreadsheets/d/1Z4_DyIjdrdpKshwrB8kGF_FXXU5BhJemF_OIkCYS49s/edit?usp=sharing

Unit Tests: N/A